### PR TITLE
Claims #23144: "too-long-mempool-chain" in send/sendtoaddress RPC error

### DIFF
--- a/bounties/surface-too-long-mempool-chain-in-send-sendtoaddress-rpc-error.md
+++ b/bounties/surface-too-long-mempool-chain-in-send-sendtoaddress-rpc-error.md
@@ -1,4 +1,10 @@
 # surface-too-long-mempool-chain-in-send-sendtoaddress-rpc-error
 
 ## Status
-Available
+Checked Out
+
+# Advances
+The main work is essentially [here](https://github.com/furszy/bitcoin/commits/2022_wallet_operationresult) (need some more love).
+
+The initial commits there are some structural changes.
+The last one contains the fix + functional test coverage.


### PR DESCRIPTION
Hey, pretty cool initiative. Was looking for something like this :).

Can check the on-going work here: https://github.com/furszy/bitcoin/commits/2022_wallet_operationresult.

I maybe went too far with the structural changes but.. let me know what you think.
Note: the fix and test coverage are on the [last commit](https://github.com/furszy/bitcoin/commit/5cb4c1ab99f770faae1a46bac402c3fc9832a54f) there.

----
Small update (09/04/22):
-> Will be doing some more changes. I'm not totally satisfied with the changes.
