### PR TITLE
check out makeseed-py-improvements bounty

### DIFF
--- a/bounties/makeseeds-py-improvements.md
+++ b/bounties/makeseeds-py-improvements.md
@@ -1,4 +1,4 @@
 # makeseeds-py-improvements
 
 ## Status
-Available
+Checked Out


### PR DESCRIPTION
I've coded a solution to the "A max of 2 seeds per ASN seems a bit strict at lest for IPv6" task in the [referenced Bitcoin repo issue](https://github.com/bitcoin/bitcoin/issues/17020).

I'm now seeing that RF5 has a [PR open](https://github.com/NYDIG/bitcoin-task-bounty/pull/3) to check out this bounty. Perhaps we could split up the individual tasks in the issue?