### PR TITLE
checkout: prune-configuration-doesnt-work-during-import

### DIFF
--- a/bounties/prune-configuration-doesnt-work-during-import.md
+++ b/bounties/prune-configuration-doesnt-work-during-import.md
@@ -1,4 +1,4 @@
 # prune-configuration-doesnt-work-during-import
 
 ## Status
-Available
+Checked Out


### PR DESCRIPTION
Hi, I'd like to checkout the bounty related to https://nydig.com/bounties/prune-configuration-doesnt-work-during-import

I've looked into this bug report and I believe that it could make sense to work. I've added a comment to the original issue inquiring as to whether the original reporter agrees and re-opens it.