### PR TITLE
Mark infinite payment loop completed

### DIFF
--- a/bounties/lnd-infinite-payment-loop.md
+++ b/bounties/lnd-infinite-payment-loop.md
@@ -1,6 +1,7 @@
 # LND Infinite Payment Loop
 
 ## Status
-Checked Out
+Completed
 
-PR with the fix: https://github.com/lightningnetwork/lnd/pull/6766
+PR merged with the fix: https://github.com/lightningnetwork/lnd/pull/6766
+Commit on master: https://github.com/lightningnetwork/lnd/commit/7e04d407b75f11c0b9b8f3b0c9f732dd863af4ae


### PR DESCRIPTION
PR merged with the fix: https://github.com/lightningnetwork/lnd/pull/6766
Commit on master: https://github.com/lightningnetwork/lnd/commit/7e04d407b75f11c0b9b8f3b0c9f732dd863af4ae

I authored these changes alongside @andreihod , which ca be seen by the mixed commit authors as well.
The payment can be done to any one of us. @andreihod has received a bounty before, so he might be a more practical recipient.