### PR TITLE
Add BPF tracepoints for mempool

### DIFF
--- a/bounties/add-bpf-tracepoints-for-the-mempool.md
+++ b/bounties/add-bpf-tracepoints-for-the-mempool.md
@@ -1,4 +1,7 @@
 # add-bpf-tracepoints-for-the-mempool
 
 ## Status
-Checked Out
+
+Completed
+
+Merge commit: https://github.com/bitcoin/bitcoin/commit/60f142e395171ab8b093a5dfae59a6a9761b38ab


### PR DESCRIPTION
Gave this a fresh try since the previous PR on this hadn't seen any updates in quite a while. Turns out @russeree had [stopped working](https://github.com/bitcoin/bitcoin/pull/26531#issuecomment-1476793337) on it.

Rewrote from scratch, included tracepoints for rejected and replaced transactions in addition to added and removed ones, and added a mempool-monitor demo script.