### PR TITLE
complete: prune-configuration-doesnt-work-during-import

### DIFF
--- a/bounties/prune-configuration-doesnt-work-during-import.md
+++ b/bounties/prune-configuration-doesnt-work-during-import.md
@@ -1,6 +1,6 @@
 # prune-configuration-doesnt-work-during-import
 
 ## Status
-Checked Out
+Completed
 
-PR with the fix: https://github.com/bitcoin/bitcoin/pull/24957
+Merge commit: https://github.com/bitcoin/bitcoin/commit/aebcd18c654a1706954a9e2c9cbfe97dfe531357


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/24957 was merged to complete prune-configuration-doesnt-work-during-import